### PR TITLE
Rollback node version to 18.17

### DIFF
--- a/.devcontainer/docker/workspace/dockerfile
+++ b/.devcontainer/docker/workspace/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.5-alpine3.17
+FROM node:18.17.1-alpine3.17
 EXPOSE 9000/tcp
 
 # Install git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "docker"
     directory: "/.devcontainer/docker/workspace/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
       with:
-        node-version: 20.3
+        node-version: 18.17.1
         cache: 'npm'
 
     - name: Installing dependencies

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
         with:
-          node-version: 20.3
+          node-version: 18.17.1
           cache: 'npm'
 
       - name: Installing dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.5-alpine3.17 as node
+FROM node:18.17.1-alpine3.17 as node
 ENV PARROT_VERSION=1.7.0
 
 LABEL org.opencontainers.image.description="Browser-based viewer for tweet archives created with the Twitter Media Downloader browser extension."


### PR DESCRIPTION
Rollbacks node version back to 18.17. 

`npm ci` fails when running under Arm on newer major node versions.