### PR TITLE
docker: Change Nginx port to 8080

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -4,8 +4,8 @@ http {
     sendfile on;
 
     server {
-        listen 80;
-        listen [::]:80;
+        listen 8080;
+        listen [::]:8080;
 
         autoindex off;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: ghcr.io/verifiedjoseph/parrot:1.7.1
+    image: parrot:latest
     container_name: Parrot
     ports:
-      - '8080:80'
+      - '8080:8080'


### PR DESCRIPTION
Changes the port used by Nginx in the docker image from `80` to `8080`.