### PR TITLE
Dockerfile: Use nginx:1.25.2-alpine3.18-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN npm run build:prod
 # Build zip
 RUN node build/zip.js
 
-FROM nginx:1.25.1-alpine3.17-slim
+FROM nginx:1.25.2-alpine3.18-slim
 
 # Copy nginx config
 COPY --from=node /app/config/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Updates Dockerfile to use Nginx 1.25.2 on Alpine 3.18-slim